### PR TITLE
Update to Nuxt 1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ Do local development
 npm run dev
 ```
 
+Do local development using node 6.10 to simulate cloud-hosted environment
+```bash
+nvm use 6.10.3
+AWS_EXECUTION_ENV=nodejs6.10 npm run dev
+```
+
 Deploy to a cloud-hosted development environment
 ```bash
 npm run deploy-dev

--- a/template/handler.js
+++ b/template/handler.js
@@ -2,7 +2,7 @@ require('./src-nuxt/lib/node-8-backcompat')
 /*
  * Handler definition for https://serverless.com/
  */
-const { Nuxt } = require('nuxt')
+const { Nuxt } = require('./nuxt-es5')
 
 let nuxtConfig = require('./nuxt.config.js')
 nuxtConfig.dev = false

--- a/template/handler.js
+++ b/template/handler.js
@@ -2,7 +2,7 @@ require('./src-nuxt/lib/node-8-backcompat')
 /*
  * Handler definition for https://serverless.com/
  */
-const { Nuxt } = require('./nuxt-es5')
+const Nuxt = require('./nuxt-es5/core/nuxt')
 
 let nuxtConfig = require('./nuxt.config.js')
 nuxtConfig.dev = false

--- a/template/handler.js
+++ b/template/handler.js
@@ -1,7 +1,8 @@
+require('./src-nuxt/lib/node-8-backcompat')
 /*
  * Handler definition for https://serverless.com/
  */
-const Nuxt = require('nuxt')
+const { Nuxt } = require('nuxt')
 
 let nuxtConfig = require('./nuxt.config.js')
 nuxtConfig.dev = false

--- a/template/nuxt.config.js
+++ b/template/nuxt.config.js
@@ -1,3 +1,5 @@
+const IS_LAMBDA = process.env.AWS_EXECUTION_ENV === 'nodejs6.10'
+
 module.exports = {
   head: {
     titleTemplate: '%s - Paca',
@@ -14,6 +16,14 @@ module.exports = {
   },
   srcDir: 'src-nuxt/',
   build: {
+    babel: {
+      presets: ({ isServer }) => [
+        [
+          require.resolve('babel-preset-vue-app'),
+          { targets: isServer ? { node: IS_LAMBDA ? '6.10.0' : '8.0.0' } : { ie: 9, uglify: true } }
+        ]
+      ]
+    },
     /*
     ** Run ESLINT on save
     */

--- a/template/package.json
+++ b/template/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-eslint": "^7.2.3",
+    "cross-env": "^5.1.3",
     "eslint": "^3.19.0",
     "eslint-config-standard": "^10.2.1",
     "eslint-loader": "^1.7.1",

--- a/template/package.json
+++ b/template/package.json
@@ -7,7 +7,8 @@
   "main": "index.js",
   "scripts": {
     "dev": "node serve-local.js",
-    "build": "cross-env AWS_EXECUTION_ENV=nodejs6.10 node -r ./src-nuxt/lib/node-8-backcompat node_modules/.bin/nuxt build",
+    "build-nuxt-es5": "node scripts/build-nuxt-es5",
+    "build": "npm run build-nuxt-es5 && cross-env AWS_EXECUTION_ENV=nodejs6.10 node -r ./src-nuxt/lib/node-8-backcompat -require ./src-nuxt/lib/babel-register node_modules/.bin/nuxt build",
     "deploy-dev": "npm run build && serverless deploy --stage dev",
     "deploy-dev-fast": "npm run build && serverless deploy --stage dev --function main",
     "deploy-prod": "npm run build && serverless deploy --stage prod"
@@ -15,12 +16,14 @@
   "dependencies": {
     "aws-serverless-express": "^3.0.0",
     "axios": "^0.16.1",
+    "babel-preset-vue-app": "^2.0.0",
     "express": "^4.15.2",
     "nuxt": "^1.1.1",
     "object.values": "^1.0.4",
     "util.promisify": "^1.0.0"
   },
   "devDependencies": {
+    "babel-cli": "^6.26.0",
     "babel-eslint": "^7.2.3",
     "eslint": "^3.19.0",
     "eslint-config-standard": "^10.2.1",
@@ -29,6 +32,8 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-node": "^4.2.2",
     "eslint-plugin-promise": "^3.5.0",
-    "eslint-plugin-standard": "^3.0.1"
+    "eslint-plugin-standard": "^3.0.1",
+    "serverless": "^1.25.0",
+    "shelljs": "^0.8.1"
   }
 }

--- a/template/package.json
+++ b/template/package.json
@@ -7,15 +7,18 @@
   "main": "index.js",
   "scripts": {
     "dev": "node serve-local.js",
-    "deploy-dev": "nuxt build && serverless deploy --stage dev",
-    "deploy-dev-fast": "nuxt build && serverless deploy --stage dev --function main",
-    "deploy-prod": "nuxt build && serverless deploy --stage prod"
+    "build": "cross-env AWS_EXECUTION_ENV=nodejs6.10 node -r ./src-nuxt/lib/node-8-backcompat node_modules/.bin/nuxt build",
+    "deploy-dev": "npm run build && serverless deploy --stage dev",
+    "deploy-dev-fast": "npm run build && serverless deploy --stage dev --function main",
+    "deploy-prod": "npm run build && serverless deploy --stage prod"
   },
   "dependencies": {
     "aws-serverless-express": "^3.0.0",
     "axios": "^0.16.1",
     "express": "^4.15.2",
-    "nuxt": "^0.10.7"
+    "nuxt": "^1.1.1",
+    "object.values": "^1.0.4",
+    "util.promisify": "^1.0.0"
   },
   "devDependencies": {
     "babel-eslint": "^7.2.3",

--- a/template/package.json
+++ b/template/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "dev": "node serve-local.js",
     "build-nuxt-es5": "node scripts/build-nuxt-es5",
-    "build": "npm run build-nuxt-es5 && cross-env AWS_EXECUTION_ENV=nodejs6.10 node -r ./src-nuxt/lib/node-8-backcompat -require ./src-nuxt/lib/babel-register node_modules/.bin/nuxt build",
+    "build": "npm run build-nuxt-es5 && cross-env AWS_EXECUTION_ENV=nodejs6.10 node -r ./src-nuxt/lib/node-8-backcompat -r ./src-nuxt/lib/babel-register node_modules/.bin/nuxt build",
     "deploy-dev": "npm run build && serverless deploy --stage dev",
     "deploy-dev-fast": "npm run build && serverless deploy --stage dev --function main",
     "deploy-prod": "npm run build && serverless deploy --stage prod"

--- a/template/package.json
+++ b/template/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "dev": "node serve-local.js",
     "build-nuxt-es5": "node scripts/build-nuxt-es5",
-    "build": "npm run build-nuxt-es5 && cross-env AWS_EXECUTION_ENV=nodejs6.10 node -r ./src-nuxt/lib/node-8-backcompat -r ./src-nuxt/lib/babel-register node_modules/.bin/nuxt build",
+    "build": "npm run build-nuxt-es5 && cross-env AWS_EXECUTION_ENV=nodejs6.10 node -r ./src-nuxt/lib/node-8-backcompat nuxt-es5/bin/nuxt-build",
     "deploy-dev": "npm run build && serverless deploy --stage dev",
     "deploy-dev-fast": "npm run build && serverless deploy --stage dev --function main",
     "deploy-prod": "npm run build && serverless deploy --stage prod"
@@ -18,7 +18,7 @@
     "axios": "^0.16.1",
     "babel-preset-vue-app": "^2.0.0",
     "express": "^4.15.2",
-    "nuxt": "^1.2.1",
+    "nuxt": "^1.3.0",
     "object.values": "^1.0.4",
     "util.promisify": "^1.0.0"
   },

--- a/template/package.json
+++ b/template/package.json
@@ -18,7 +18,7 @@
     "axios": "^0.16.1",
     "babel-preset-vue-app": "^2.0.0",
     "express": "^4.15.2",
-    "nuxt": "^1.1.1",
+    "nuxt": "^1.2.1",
     "object.values": "^1.0.4",
     "util.promisify": "^1.0.0"
   },

--- a/template/scripts/build-nuxt-es5.js
+++ b/template/scripts/build-nuxt-es5.js
@@ -10,3 +10,6 @@ shell.rm('-rf', 'nuxt-es5/core')
 shell.exec('npx babel-cli -D -d nuxt-es5/builder node_modules/nuxt/lib/builder')
 shell.exec('npx babel-cli -D -d nuxt-es5/common node_modules/nuxt/lib/common')
 shell.exec('npx babel-cli -D -d nuxt-es5/core node_modules/nuxt/lib/core')
+
+shell.mkdir('nuxt-es5/bin')
+shell.cp('node_modules/nuxt/bin/nuxt-build', 'nuxt-es5/bin/nuxt-build')

--- a/template/scripts/build-nuxt-es5.js
+++ b/template/scripts/build-nuxt-es5.js
@@ -1,0 +1,12 @@
+/* eslint no-console: 0 */
+const shell = require('shelljs')
+shell.rm('-rf', 'nuxt-es5')
+shell.cp('-r', 'node_modules/nuxt/lib', 'nuxt-es5')
+
+shell.rm('-rf', 'nuxt-es5/builder')
+shell.rm('-rf', 'nuxt-es5/common')
+shell.rm('-rf', 'nuxt-es5/core')
+
+shell.exec('npx babel-cli -D -d nuxt-es5/builder node_modules/nuxt/lib/builder')
+shell.exec('npx babel-cli -D -d nuxt-es5/common node_modules/nuxt/lib/common')
+shell.exec('npx babel-cli -D -d nuxt-es5/core node_modules/nuxt/lib/core')

--- a/template/serve-local.js
+++ b/template/serve-local.js
@@ -1,4 +1,7 @@
-const Nuxt = require('nuxt')
+if (process.env.AWS_EXECUTION_ENV === 'nodejs6.10') {
+  require('./src-nuxt/lib/node-8-backcompat')
+}
+const { Nuxt, Builder } = require('nuxt')
 const express = require('express')
 
 const HOST = process.env.HOST || 'localhost'
@@ -17,7 +20,7 @@ const nuxt = new Nuxt(nuxtConfig)
 app.use(nuxt.render)
 
 if (nuxtConfig.dev) {
-  nuxt.build()
+  new Builder(nuxt).build()
   .catch((error) => {
     console.error(error)
     process.exit(1)

--- a/template/serve-local.js
+++ b/template/serve-local.js
@@ -1,7 +1,8 @@
-if (process.env.AWS_EXECUTION_ENV === 'nodejs6.10') {
-  require('./src-nuxt/lib/node-8-backcompat')
+const IS_LAMBDA = process.env.AWS_EXECUTION_ENV === 'nodejs6.10'
+if (IS_LAMBDA) {
+  require('./util/node-8-backcompat')
 }
-const { Nuxt, Builder } = require('nuxt')
+const { Nuxt, Builder } = require(IS_LAMBDA ? './nuxt-es5' : 'nuxt')
 const express = require('express')
 
 const HOST = process.env.HOST || 'localhost'

--- a/template/src-nuxt/lib/babel-register.js
+++ b/template/src-nuxt/lib/babel-register.js
@@ -1,0 +1,6 @@
+require('babel-register')({
+  only: /nuxt\/lib/,
+  presets: [
+    [ 'env', { targets: { node: '6.10' } } ],
+  ],
+})

--- a/template/src-nuxt/lib/node-8-backcompat.js
+++ b/template/src-nuxt/lib/node-8-backcompat.js
@@ -1,0 +1,13 @@
+const util = require('util')
+if (!util.promisify) {
+  require('util.promisify/shim')()
+}
+if (!Object.values) {
+  require('object.values').shim()
+}
+require('babel-register')({
+  only: /nuxt\/lib/,
+  presets: [
+    [ 'env', { targets: { node: 'current' } } ]
+  ]
+})

--- a/template/src-nuxt/lib/node-8-backcompat.js
+++ b/template/src-nuxt/lib/node-8-backcompat.js
@@ -5,9 +5,3 @@ if (!util.promisify) {
 if (!Object.values) {
   require('object.values').shim()
 }
-require('babel-register')({
-  only: /nuxt\/lib/,
-  presets: [
-    [ 'env', { targets: { node: 'current' } } ]
-  ]
-})


### PR DESCRIPTION
* Add shims for node 8 features that are missing in node 6
* Create a new module that activates these shims
* Create a script that bablifies nuxt into `./nuxt-es5`
* Explicitly specify nuxt.config.js babel presets to change node tgt depending on env var
* Modify `serve-local.js` and `handler.js` to use nuxt 1.x conventions and the bablified nuxt
* Update README to point out additonal complexity that users have to be aware of

This resolves #5  (or at least attempts to), and is based in part on datagovsg/beeline-landing#32
