### PR TITLE
Upgrade de Nuxt version and added serverless-offline for emulate server

### DIFF
--- a/template/.gitignore
+++ b/template/.gitignore
@@ -13,3 +13,7 @@ npm-debug.log*
 
 # Serverless directories
 .serverless
+
+# Libraries block
+package-lock.json
+yarn.lock

--- a/template/handler.js
+++ b/template/handler.js
@@ -1,15 +1,16 @@
 /*
  * Handler definition for https://serverless.com/
  */
-const Nuxt = require('nuxt')
+const express = require('express')
+const awsServerlessExpress = require('aws-serverless-express')
+const awsServerlessExpressMiddleware = require('aws-serverless-express/middleware')
+const { Nuxt } = require('nuxt')
 
 let nuxtConfig = require('./nuxt.config.js')
 nuxtConfig.dev = false
 const nuxt = new Nuxt(nuxtConfig)
 
-const awsServerlessExpressMiddleware = require('aws-serverless-express/middleware')
-const awsServerlessExpress = require('aws-serverless-express')
-const app = require('express')()
+const app = express()
 const server = awsServerlessExpress.createServer(app)
 
 app.use('/api', require('./src-api'))

--- a/template/package.json
+++ b/template/package.json
@@ -6,6 +6,8 @@
   "private": true,
   "main": "index.js",
   "scripts": {
+    "build": "nuxt build",
+    "serve": "nuxt build && sls offline start",
     "dev": "node serve-local.js",
     "deploy-dev": "nuxt build && serverless deploy --stage dev",
     "deploy-dev-fast": "nuxt build && serverless deploy --stage dev --function main",
@@ -15,7 +17,7 @@
     "aws-serverless-express": "^3.0.0",
     "axios": "^0.16.1",
     "express": "^4.15.2",
-    "nuxt": "^0.10.7"
+    "nuxt": "1.0.0-rc11"
   },
   "devDependencies": {
     "babel-eslint": "^7.2.3",
@@ -26,6 +28,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-node": "^4.2.2",
     "eslint-plugin-promise": "^3.5.0",
-    "eslint-plugin-standard": "^3.0.1"
+    "eslint-plugin-standard": "^3.0.1",
+    "serverless-offline": "^3.18.0"
   }
 }

--- a/template/serve-local.js
+++ b/template/serve-local.js
@@ -1,9 +1,11 @@
-const Nuxt = require('nuxt')
+const { Nuxt, Builder } = require('nuxt')
 const express = require('express')
 
 const HOST = process.env.HOST || 'localhost'
 const PORT = process.env.PORT || 3000
 const app = express()
+
+app.set('port', PORT)
 
 process.env.HOST = HOST
 process.env.PORT = PORT
@@ -11,18 +13,16 @@ process.env.PORT = PORT
 app.use('/api', require('./src-api'))
 
 let nuxtConfig = require('./nuxt.config.js')
-nuxtConfig.dev = (process.env.NODE_ENV !== 'production')
+nuxtConfig.dev = !(process.env.NODE_ENV === 'production')
 
 const nuxt = new Nuxt(nuxtConfig)
-app.use(nuxt.render)
 
 if (nuxtConfig.dev) {
-  nuxt.build()
-  .catch((error) => {
-    console.error(error)
-    process.exit(1)
-  })
+  const builder = new Builder(nuxt)
+  builder.build()
 }
+
+app.use(nuxt.render)
 
 app.listen(PORT, HOST)
 console.log(`Server listening on ${HOST}:${PORT}`)

--- a/template/src-nuxt/pages/index.vue
+++ b/template/src-nuxt/pages/index.vue
@@ -17,7 +17,7 @@
 </template>
 
 <script>
-import Logo from '~components/Logo.vue'
+import Logo from '~/components/Logo.vue'
 
 export default {
   components: {


### PR DESCRIPTION
### Changes:
- Upgraded the Nuxt version to v1.0.0-rc11
- Added `serverless-offline` plugin for emulate AWS server
- Removed library locker files (package-lock.json, yarn.lock)
- Some refactoring

### Notes:
- The v1.0.0-rc11 Nuxt version is the latest version supported by Node 6. From v1.0.0 is only supported by Node 8. For now, AWS Lambda support only Node 4 and Node 6.
- Now for import files using the Nuxt path relative helpers (~, @) you need to add a trailing slash, [See v1.0.0-rc3 breaking changes](https://github.com/nuxt/nuxt.js/releases/tag/v1.0.0-rc3). Example:

Before:
`import Logo from '~components/Logo.vue'`

Now:
`import Logo from '~/components/Logo.vue'`